### PR TITLE
fix minor Makefile bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ OCAMLOPT=ocamlfind ocamlopt
 	$(OCAML) $(FLAGS) -c $<
 
 interp: $(OBJS)
-	$(OCAML) $(FLAGS) -linkpkg -o $@ $<
+	$(OCAML) $(FLAGS) -linkpkg -o $@ $+
 
 interpopt: $(OBJS:.cmo=.cmx)
-	$(OCAMLOPT) $(FLAGS) -linkpkg -o $@ $<
+	$(OCAMLOPT) $(FLAGS) -linkpkg -o $@ $+


### PR DESCRIPTION
There is a bug in Makefile that is not observable today: the rules for building an executable use `ocamlc -o $@ $<`, but selects the first dependency only, which happens to work because OBJS contains a unique object.

If you later split the codebase in several modules (as I did in a branch), then only the first one would get linked by the rule. The fix uses `$+` which is recommended by [the GNU make documentation](https://www.gnu.org/software/make/manual/html_node/Automatic-Variables.html) for linking -- but `$^` would also be fine.