### PR TITLE
Minimalism (2/n)

### DIFF
--- a/data.ml
+++ b/data.ml
@@ -185,7 +185,7 @@ exception InternalException of value
 
 let unit = ptr @@ Constructor ("()", 0, None)
 
-let rec is_true = onptr @@ function
+let is_true = onptr @@ function
   | Constructor ("true", _, None) -> true
   | Constructor ("false", _, None) -> false
   | _ -> assert false
@@ -380,7 +380,7 @@ let next_exn_id =
     !last_exn_id
 
 exception No_module_data
-let get_module_data env loc = function
+let get_module_data loc = function
   | Module data -> data
   | Functor _ ->
      Format.eprintf "%a@.Tried to access the components of a functor@."

--- a/envir.ml
+++ b/envir.ml
@@ -80,7 +80,7 @@ let make_module_data env =
   let values env_map =
     env_map
     |> SMap.filter (fun _ -> function
-          | Value v -> true
+          | Value _v -> true
           | Instance_variable _ -> false)
     |> SMap.map (function
            | Value v -> v
@@ -138,4 +138,4 @@ and env_get_class env ({ loc; _ } as lid) =
   lookup "class" ~env_name env.classes { txt = id; loc }
 
 and env_get_module_data env ({ loc; _ } as id) =
-  get_module_data env loc (env_get_module env id)
+  get_module_data loc (env_get_module env id)

--- a/interp.ml
+++ b/interp.ml
@@ -358,10 +358,14 @@ let run_files () =
 
 (* let _ = load_rec_units stdlib_env [stdlib_flag, "test.ml"] *)
 let () =
+  let open Conf in
   try match Conf.command () with
-        | Some Conf.Ocamlc -> run_ocamlc ()
-        | Some Conf.Ocamlopt -> run_ocamlopt ()
-        | Some Conf.Files -> run_files ()
-        | None -> run_ocamlc ()
+    | Some cmd ->
+      begin match cmd with
+        | Ocamlc -> run_ocamlc ()
+        | Ocamlopt -> run_ocamlopt ()
+        | Files -> run_files ()
+      end
+    | None -> run_ocamlc ()
   with InternalException e ->
     Format.eprintf "Code raised exception: %a@." pp_print_value e

--- a/miniml/compiler/compile.scm
+++ b/miniml/compiler/compile.scm
@@ -1408,23 +1408,26 @@
         (else (assert #f))))
 
 (define (expr-fv-binding expr env args)
-  (expr-fv expr
-           (fold (lambda (name env)
-                   (env-with-vars env (vhash-replace name (cons #t (mkvar (list 'VarGlobal "dummy") "dummy")) (env-get-vars env))))
-                 env args)))
+  (expr-fv expr (fold fv-env-var env args)))
 
 (define (branch-fv b env)
+  (let ((p (car b))
+        (e (cdr b)))
+    (expr-fv e (fv-env-pat p env))))
+
+(define (fv-env-var arg env)
+  (env-with-vars env (vhash-replace arg (cons #t (mkvar (list 'VarGlobal "dummy") "dummy")) (env-get-vars env))))
+
+(define (fv-env-pat p env)
   (cond
-   ((equal? (car (car b)) 'PVar)
-    (let* ((v (car (cdr (car b))))
-           (e (cdr b)))
-      (expr-fv-binding e env (list v))))
-   ((equal? (car (car b)) 'PInt)
-    (expr-fv (cdr b) env))
-   ((equal? (car (car b)) 'PConstr)
-    (let* ((l (car (cdr (cdr (car b)))))
-           (e (cdr b)))
-      (expr-fv-binding e env l)))
+   ((equal? (car p) 'PVar)
+    (let ((v (car (cdr p))))
+      (fv-env-var v env)))
+   ((equal? (car p) 'PInt)
+    env)
+   ((equal? (car p) 'PConstr)
+    (let ((l (car (cdr (cdr p)))))
+      (fold fv-env-var env l)))
    (else (assert #f))))
 
 (define (range a b) (if (>= a b) #nil (cons a (range (+ a 1) b))))

--- a/miniml/compiler/compile.scm
+++ b/miniml/compiler/compile.scm
@@ -262,10 +262,8 @@
     (longident_lident list_labelled_simple_expr ATAT expr_no_semi):
       ;; (f e1 .. en @@ e) ~> f e1 .. en e
       (list 'EApply $1 (append $2 (list (mknolabel $4))))
-    (MATCH expr WITH pattern_lines) : (list 'EMatch $2 $4)
-    (TRY expr WITH pattern_lines) : (list 'ETry $2 $4)
-    (MATCH expr WITH BAR pattern_lines) : (list 'EMatch $2 $5)
-    (TRY expr WITH BAR pattern_lines) : (list 'ETry $2 $5)
+    (MATCH expr WITH clauses) : (list 'EMatch $2 $4)
+    (TRY expr WITH clauses) : (list 'ETry $2 $4)
     (LET llet llet_ands IN expr (prec: LET)) : (list 'ELet (cons $2 $3) $5)
     (LET OPEN longident_uident IN expr (prec: LET)) : (list 'ELetOpen $3 $5)
     (expr_no_semi COLONCOLON expr_no_semi) : (list 'EConstr (list 'Lident "Cons") (cons $1 (cons $3 #nil)))
@@ -287,9 +285,16 @@
     ( ) : #nil
     (AND llet llet_ands) : (cons $2 $3))
 
-   (pattern_lines
-    (pattern MINUSGT expr) : (cons (cons $1 $3) #nil)
-    (pattern MINUSGT expr BAR pattern_lines) : (cons (cons $1 $3) $5))
+   (clauses
+    (clauses_without_bar) : $1
+    (BAR clauses_without_bar) : $2)
+
+   (clauses_without_bar
+    (clause) : (list $1)
+    (clause BAR clauses_without_bar) : (cons $1 $3))
+
+   (clause
+    (pattern MINUSGT expr) : (cons $1 $3))
 
    (field_decl
     (LIDENT COLON type_ignore) : $1

--- a/miniml/compiler/compile.scm
+++ b/miniml/compiler/compile.scm
@@ -81,19 +81,21 @@
     (AND letdef let_ands) : (cons $2 $3))
 
    (letdef
-    (LIDENT list_labelled_args EQ expr) : (cons $1 (cons $2 $4)))
+    (LIDENT list_labelled_arg EQ expr) : (cons $1 (cons $2 $4)))
 
-   (list_labelled_args
+   (list_labelled_arg
     ( ) : #nil
-    (labelled_args list_labelled_args) : (cons $1 $2))
+    (labelled_arg list_labelled_arg) : (cons $1 $2))
 
-   (labelled_args
-    (LIDENT) : (cons $1 (cons (list 'Nolabel) (list 'None)))
-    (TILDE LIDENT) : (cons $2 (cons (list 'Labelled $2) (list 'None)))
-    (QUESTION LIDENT) : (cons $2 (cons (list 'Optional $2) (list 'None)))
-    (LPAREN LIDENT COLON type_ignore RPAREN) : (cons $2 (cons (list 'Nolabel) (list 'None)))
-    (LPAREN RPAREN) : (cons "_" (cons (list 'Nolabel) (list 'None)))
-    (QUESTION LPAREN LIDENT EQ expr RPAREN) : (cons $3 (cons (list 'Optional $3) (list 'Some $5))))
+   (nonempty_list_labelled_arg
+    (labelled_arg) : (list $1)
+    (labelled_arg nonempty_list_labelled_arg) : (cons $1 $2))
+
+   (labelled_arg
+    (simple_pattern) : (cons $1 (cons (list 'Nolabel) (list 'None)))
+    (TILDE LIDENT) : (cons (list 'PVar $2) (cons (list 'Labelled $2) (list 'None)))
+    (QUESTION LIDENT) : (cons (list 'PVar $2) (cons (list 'Optional $2) (list 'None)))
+    (QUESTION LPAREN LIDENT EQ expr RPAREN) : (cons (list 'PVar $3) (cons (list 'Optional $3) (list 'Some $5))))
 
    (constr_decl
     (UIDENT) : (cons $1 0)
@@ -178,15 +180,18 @@
     (comma_separated_list2_expr COMMA expr_no_semi) : (cons $3 $1))
 
    (pattern
-    (LIDENT) : (list 'PVar $1)
-    (longident_constr) : (list 'PConstr $1 #nil)
+    (simple_pattern) : $1
     (longident_constr LIDENT) : (list 'PConstr $1 (cons $2 #nil))
     (longident_constr LPAREN pattern_constr_args RPAREN) : (list 'PConstr $1 $3)
     (comma_separated_list2_lident) : (list 'PConstr (list 'Lident "") (reverse $1))
+    (LIDENT COLONCOLON LIDENT) : (list 'PConstr (list 'Lident "Cons") (cons $1 (cons $3 #nil))))
+
+   (simple_pattern
+    (LIDENT) : (list 'PVar $1)
+    (longident_constr) : (list 'PConstr $1 #nil)
     (LBRACK RBRACK) : (list 'PConstr (list 'Lident "Null") #nil)
-    (LIDENT COLONCOLON LIDENT) : (list 'PConstr (list 'Lident "Cons") (cons $1 (cons $3 #nil)))
     (LPAREN pattern COLON type_ignore RPAREN) : $2
-    (LPAREN RPAREN) : (list 'PInt "0")
+    (LPAREN RPAREN) : (list 'PInt 0)
     (LPAREN pattern RPAREN) : $2
     (INT) : (list 'PInt $1))
 
@@ -226,7 +231,7 @@
 
    (expr_no_semi
     (simple_expr) : $1
-    (FUN nonempty_list_lident MINUSGT expr) : (list 'ELambda $2 $4)
+    (FUN nonempty_list_labelled_arg MINUSGT expr) : (list 'ELambda $2 $4)
     (longident_lident nonempty_list_labelled_simple_expr) : (list 'EApply $1 $2)
     (longident_constr simple_expr) : (list 'EConstr $1 (cons $2 #nil))
     (comma_separated_list2_expr (prec: comma_prec)) : (list 'EConstr (list 'Lident "") (reverse $1))
@@ -264,7 +269,7 @@
 
    (llet
     (pattern EQ expr) : (cons $1 $3)
-    (LIDENT nonempty_list_lident EQ expr) : (cons (list 'PVar $1) (list 'ELambda $2 $4)))
+    (LIDENT nonempty_list_labelled_arg EQ expr) : (cons (list 'PVar $1) (list 'ELambda $2 $4)))
 
    (llet_ands
     ( ) : #nil
@@ -1296,7 +1301,7 @@
         ((equal? (car expr) 'ELambda)
          (let* ((args (car (cdr expr)))
                 (body (car (cdr (cdr expr)))))
-           (compile-fundef env stacksize (map (lambda (arg) (cons arg (cons (list 'Nolabel) (list 'None)))) args) body)))
+           (compile-fundef env stacksize args body)))
         (else (assert #f))))
 
 (define (compile-expr-list env stacksize l)
@@ -1326,7 +1331,8 @@
 (define (get-def-name d) (car d))
 (define (get-def-args d) (car (cdr d)))
 (define (get-def-body d) (cdr (cdr d)))
-(define (get-arg-name a) (car a))
+
+(define (get-arg-pat a) (car a))
 (define (get-arg-label a) (car (cdr a)))
 (define (get-arg-default a) (cdr (cdr a)))
 
@@ -1403,8 +1409,9 @@
            ))
         ((equal? (car expr) 'ELambda)
          (let* ((args (car (cdr expr)))
+                (pats (map get-arg-pat args))
                 (body (car (cdr (cdr expr)))))
-           (expr-fv-binding body env args)))
+           (expr-fv body (fold fv-env-pat env pats))))
         (else (assert #f))))
 
 (define (expr-fv-binding expr env args)
@@ -1430,25 +1437,21 @@
       (fold fv-env-var env l)))
    (else (assert #f))))
 
+
 (define (range a b) (if (>= a b) #nil (cons a (range (+ a 1) b))))
 
 (define (compile-fundef env stacksize args basebody)
-  (let* ((body (fold-right
-                (lambda (arg body)
+  (let* ((arity (length args))
+         (arg-names (map compile-arg-name args (range 0 arity)))
+         (body (fold-right
+                (lambda (arg name body)
                   (if (equal? (car (get-arg-default arg)) 'Some)
-                      (let* ((name (get-arg-name arg))
-                             (def (car (cdr (get-arg-default arg))))
-                             (noneline (cons (list 'PConstr (list 'Lident "None") #nil) def))
-                             (someline (cons (list 'PConstr (list 'Lident "Some") (list name))
-                                             (list 'EVar (list 'Lident name))))
-                             (match (list 'EMatch (list 'EVar (list 'Lident name)) (list noneline someline))))
-                        (list 'ELet (list (cons (list 'PVar name) match)) body))
-                      body))
-                basebody args))
-         (arity (length args))
+                      (compile-arg-default (get-arg-label arg) (get-arg-default arg) body)
+                      (compile-arg-pat (get-arg-pat arg) name body)))
+                basebody args arg-names))
          (lab1 (newlabel))
          (lab2 (newlabel))
-         (fv (map car (vlist->list (expr-fv-binding body env (map get-arg-name args)))))
+         (fv (map car (vlist->list (expr-fv-binding body env arg-names))))
          (nfv (fold (lambda (name i nfv) (vhash-replace name i nfv)) vlist-null fv (range 0 (length fv))))
          (mvars (vhash-filter-map
                  (lambda (name v)
@@ -1459,7 +1462,7 @@
                              (cons (car v) (mkvar (list 'VarEnv (cdr r)) (get-var-funshape (cdr v))))
                              #f))))
                  (env-get-vars env)))
-         (nvars (fold (lambda (arg i vs) (vhash-replace (get-arg-name arg) (cons #t (mkvar (list 'VarStack (- (- arity 1) i)) #nil)) vs)) mvars args (range 0 arity)))
+         (nvars (fold (lambda (arg-name i vs) (vhash-replace arg-name (cons #t (mkvar (list 'VarStack (- (- arity 1) i)) #nil)) vs)) mvars arg-names (range 0 arity)))
          (nenv (env-with-vars env nvars))
          )
     (assert (> arity 0))
@@ -1478,6 +1481,32 @@
     (bytecode-put-u32-le (length fv))
     (bytecode-emit-labref lab2)
   ))
+
+(define (compile-arg-name a i)
+  (let ((p (get-arg-pat a)))
+    (cond
+     ((equal? (car p) 'PVar)
+      (car (cdr p)))
+     (else
+      (string-append "arg#" (number->string i))))))
+
+(define (compile-arg-default label default body)
+  (assert (equal? (car label) 'Optional))
+  (assert (equal? (car default) 'Some))
+  (let* ((name (car (cdr label)))
+         (def (car (cdr default)))
+         (noneline (cons (list 'PConstr (list 'Lident "None") #nil) def))
+         (someline (cons (list 'PConstr (list 'Lident "Some") (list name))
+                         (list 'EVar (list 'Lident name))))
+         (match (list 'EMatch (list 'EVar (list 'Lident name)) (list noneline someline))))
+    (list 'ELet (list (cons (list 'PVar name) match)) body)))
+
+(define (compile-arg-pat pat name body)
+  (if (equal? (car pat) 'PVar)
+      body
+      (list 'EMatch
+            (list 'EVar (list 'Lident name))
+            (list (cons pat body)))))
 
 (define (compile-type env name tdef)
   (cond ((equal? (car tdef) 'ISum)

--- a/miniml/compiler/compile.scm
+++ b/miniml/compiler/compile.scm
@@ -82,6 +82,7 @@
     (AND letdef let_ands) : (cons $2 $3))
 
    (letdef
+    (LPAREN RPAREN EQ expr) : (cons "_" (cons #nil $4))
     (LIDENT list_labelled_arg EQ expr) : (cons $1 (cons $2 $4)))
 
    (list_labelled_arg

--- a/miniml/compiler/hello.ml
+++ b/miniml/compiler/hello.ml
@@ -74,11 +74,15 @@ let rec go n =
 let () = go 10
 let () = caml_ml_flush stdout
 
+let () = print "\nPattern-matching:\n"
+
 let () =
   print_int (match Null with Null -> 2 | Cons (x, l) -> 3)
 
 let () =
-  print_int (match Cons (1, Null) with Null -> 2 | Cons (x, l) -> 3)
+  print_int (match Cons (1, Null) with
+    | Null -> 2 (* note: leading bar *)
+    | Cons (x, l) -> 3)
 
 let () = print "\nLists:\n"
 
@@ -150,7 +154,8 @@ let () =
 
 let () =
   try raise (E2 7) with
-  | E2 x -> if x = 7 then print " ok" else print " ko"
+    (* note: no leading bar *)
+    E2 x -> if x = 7 then print " ok" else print " ko"
   | _ -> print " ko"
 
 let () = print (try " ok" with _ -> " ko")

--- a/miniml/compiler/hello.ml
+++ b/miniml/compiler/hello.ml
@@ -130,6 +130,8 @@ let _ =
   print_int v.a; print_int v.b;
   print_int w.a; print_int w.b
 
+let _ = print "\nExceptions:\n"
+
 exception E1
 exception E2 of int
 exception E3
@@ -166,6 +168,8 @@ let _ = print " "; show_exn (E2 7)
 let _ = print " "; show_exn E3
 let _ = print " "; show_exn (E4 7)
 
+let _ = print "\nopen:\n"
+
 module M = struct
   let x = 42
   let f x = x + x
@@ -176,4 +180,12 @@ let _ =
   let open M in
   print_int (f 42)
 
+let _ = print "\nInfix operators treated as sugar:\n"
+
+let succ n = n + 1
+let ignore_and_print_int () n = print_int n
+let _ = ignore_and_print_int () @@ succ @@ 1
+let _ = 2 |> succ |> ignore_and_print_int ()
+
+let _ = print "\n"
 let _ = caml_ml_flush stdout

--- a/miniml/compiler/hello.ml
+++ b/miniml/compiler/hello.ml
@@ -84,6 +84,13 @@ let () =
     | Null -> 2 (* note: leading bar *)
     | Cons (x, l) -> 3)
 
+let test_function = function
+  | Null -> 2
+  | Cons (x, l) -> x + 1
+
+let () =
+  print_int (test_function (Cons (3, Null)))
+
 let () = print "\nLists:\n"
 
 let rec iter f l =

--- a/miniml/compiler/hello.ml
+++ b/miniml/compiler/hello.ml
@@ -80,6 +80,8 @@ let _ =
 let _ =
   print_int (match Cons (1, Null) with Null -> 2 | Cons (x, l) -> 3)
 
+let _ = print "\nLists:\n"
+
 let rec iter f l =
   match l with
   | [] -> ()
@@ -98,6 +100,9 @@ let rec map f l =
 
 let _ = print_list (map (fun x -> x + 1) [1; 2; 3; 4; 5; 6; 7; 8; 9])
 
+let _ = print_list (map (fun (x, y) -> x + y) [(1, 1); (2, 2); (3, 3)])
+
+let _ = print "\nArguments:\n"
 
 let f1 ~x ~y = print_int (x + 2 * y)
 let _ = f1 0 1
@@ -110,6 +115,12 @@ let _ = f2 ~y:101 (* Note: this is different from ocaml *)
 let _ = f2 ?x:None ~y:102
 let _ = f2 ?x:(Some 0) ~y:103
 let _ = f2 ~x:0 ~y:104
+
+let f3 () ?(x=1) (y1, y2) ~z = print_int x; print_int y1; print_int y2; print_int z
+let _ = f3 () (2, 3) ~z:4
+let _ = f3 () ~x:0 (1, 2) ~z:3
+
+let _ = print "\nRecords:\n"
 
 let _ =
   let u = { a = 5 ; b = 7 } in

--- a/miniml/compiler/hello.ml
+++ b/miniml/compiler/hello.ml
@@ -23,7 +23,7 @@ let print_int n = print (format_int " %d" n)
 let _ = print "Hello, world!\n"
 
 let _ = print_int (6 * 7)
-let _ = print_int (17 + 12)
+let () = print_int (17 + 12)
 
 (* let g x = let z = x * 2 in fun y -> z * 3 *)
 
@@ -31,56 +31,56 @@ let g x y = x - y
 
 let h = g 6
 
-let _ = print_int (6 - 3)
-let _ = print_int (g 6 3)
-let _ = print_int (h 3)
+let () = print_int (6 - 3)
+let () = print_int (g 6 3)
+let () = print_int (h 3)
 
 let f1 = fun x -> fun y -> x * y
 let f2 = f1 6
 
-let _ = print_int (f2 7)
+let () = print_int (f2 7)
 
 let double f x = f (f x)
 let add2n n x = double (plus n) x
 
-let _ = print_int (add2n 20 2)
-let _ = print_int (double double double double (plus 1) 0)
-let _ = print_int (if false then 17 else 42)
-let _ = print_int (if true then 17 else 42)
+let () = print_int (add2n 20 2)
+let () = print_int (double double double double (plus 1) 0)
+let () = print_int (if false then 17 else 42)
+let () = print_int (if true then 17 else 42)
 
 let f x = let x = x + x in x + x + x
-let _ = print_int (f 7)
+let () = print_int (f 7)
 
-let _ =
+let () =
   let twice x = x + x in print_int (twice 21)
 
-let _ =
+let () =
   let u = { a = 5 ; b = 7 } in
   print_int u.a; print_int u.b
 
-let _ =
+let () =
   let u = { b = 5 ; a = 7 } in
   print_int u.a; print_int u.b
 
 
-let _ = print_int (let a = 17 in let b = 42 in if (let x = 2 in true) then a else b)
-let _ = print_int (let a = 17 in let b = 42 in if (let x = 2 in false) then a else b)
+let () = print_int (let a = 17 in let b = 42 in if (let x = 2 in true) then a else b)
+let () = print_int (let a = 17 in let b = 42 in if (let x = 2 in false) then a else b)
 
-let _ = caml_ml_flush stdout
+let () = caml_ml_flush stdout
 
 let rec go n =
   if n = 0 then () else (print_int n; go (n - 1))
 
-let _ = go 10
-let _ = caml_ml_flush stdout
+let () = go 10
+let () = caml_ml_flush stdout
 
-let _ =
+let () =
   print_int (match Null with Null -> 2 | Cons (x, l) -> 3)
 
-let _ =
+let () =
   print_int (match Cons (1, Null) with Null -> 2 | Cons (x, l) -> 3)
 
-let _ = print "\nLists:\n"
+let () = print "\nLists:\n"
 
 let rec iter f l =
   match l with
@@ -91,38 +91,38 @@ let rec iter f l =
 let print_list l =
   print "["; iter print_int l; print "]"
 
-let _ = print_list [1; 2; 3; 4; 5; 6; 7; 8; 9]
+let () = print_list [1; 2; 3; 4; 5; 6; 7; 8; 9]
 
 let rec map f l =
   match l with
   | [] -> []
   | x :: l -> f x :: map f l
 
-let _ = print_list (map (fun x -> x + 1) [1; 2; 3; 4; 5; 6; 7; 8; 9])
+let () = print_list (map (fun x -> x + 1) [1; 2; 3; 4; 5; 6; 7; 8; 9])
 
-let _ = print_list (map (fun (x, y) -> x + y) [(1, 1); (2, 2); (3, 3)])
+let () = print_list (map (fun (x, y) -> x + y) [(1, 1); (2, 2); (3, 3)])
 
-let _ = print "\nArguments:\n"
+let () = print "\nArguments:\n"
 
 let f1 ~x ~y = print_int (x + 2 * y)
-let _ = f1 0 1
-let _ = f1 ~x:0 ~y:1
-let _ = f1 ~y:1 ~x:0
+let () = f1 0 1
+let () = f1 ~x:0 ~y:1
+let () = f1 ~y:1 ~x:0
 
 let f2 ?(x=1) ~y = print_int (x + 2 * y)
-let _ = f2 100
-let _ = f2 ~y:101 (* Note: this is different from ocaml *)
-let _ = f2 ?x:None ~y:102
-let _ = f2 ?x:(Some 0) ~y:103
-let _ = f2 ~x:0 ~y:104
+let () = f2 100
+let () = f2 ~y:101 (* Note: this is different from ocaml *)
+let () = f2 ?x:None ~y:102
+let () = f2 ?x:(Some 0) ~y:103
+let () = f2 ~x:0 ~y:104
 
 let f3 () ?(x=1) (y1, y2) ~z = print_int x; print_int y1; print_int y2; print_int z
-let _ = f3 () (2, 3) ~z:4
-let _ = f3 () ~x:0 (1, 2) ~z:3
+let () = f3 () (2, 3) ~z:4
+let () = f3 () ~x:0 (1, 2) ~z:3
 
-let _ = print "\nRecords:\n"
+let () = print "\nRecords:\n"
 
-let _ =
+let () =
   let u = { a = 5 ; b = 7 } in
   let v = { u with a = 42 } in
   let w = { u with b = 16 } in
@@ -130,7 +130,7 @@ let _ =
   print_int v.a; print_int v.b;
   print_int w.a; print_int w.b
 
-let _ = print "\nExceptions:\n"
+let () = print "\nExceptions:\n"
 
 exception E1
 exception E2 of int
@@ -143,49 +143,49 @@ let show_exn e =
   | E2 i -> print "(E2"; print_int i; print ")"
   | _ -> print "<unknown>"
 
-let _ =
+let () =
   try raise E1 with
   | E1 -> print " ok"
   | _ -> print " ko"
 
-let _ =
+let () =
   try raise (E2 7) with
   | E2 x -> if x = 7 then print " ok" else print " ko"
   | _ -> print " ko"
 
-let _ = print (try " ok" with _ -> " ko")
+let () = print (try " ok" with _ -> " ko")
 
-let _ = try (try raise E1 with E2 _ -> print " ko") with E1 -> print " ok" | _ -> print " ko"
-let _ = try (try raise (E2 7) with E1 -> print " ko") with E2 x -> if x = 7 then print " ok" else print " ko" | _ -> print " ko"
-let _ = try (try raise E3 with E1 -> print " ko" | E2 _ -> print " ko") with _ -> print " ok"
-let _ = try (try raise (E4 7) with E1 -> print " ko" | E2 _ -> print " ko") with _ -> print " ok"
+let () = try (try raise E1 with E2 _ -> print " ko") with E1 -> print " ok" | _ -> print " ko"
+let () = try (try raise (E2 7) with E1 -> print " ko") with E2 x -> if x = 7 then print " ok" else print " ko" | _ -> print " ko"
+let () = try (try raise E3 with E1 -> print " ko" | E2 _ -> print " ko") with _ -> print " ok"
+let () = try (try raise (E4 7) with E1 -> print " ko" | E2 _ -> print " ko") with _ -> print " ok"
 
-let _ = try (try raise E1 with E1 -> print " ok") with _ -> print " ko"
-let _ = try (try raise (E2 7) with E2 x -> if x = 7 then print " ok" else print " ko") with _ -> print " ko"
+let () = try (try raise E1 with E1 -> print " ok") with _ -> print " ko"
+let () = try (try raise (E2 7) with E2 x -> if x = 7 then print " ok" else print " ko") with _ -> print " ko"
 
-let _ = print " "; show_exn E1
-let _ = print " "; show_exn (E2 7)
-let _ = print " "; show_exn E3
-let _ = print " "; show_exn (E4 7)
+let () = print " "; show_exn E1
+let () = print " "; show_exn (E2 7)
+let () = print " "; show_exn E3
+let () = print " "; show_exn (E4 7)
 
-let _ = print "\nopen:\n"
+let () = print "\nopen:\n"
 
 module M = struct
   let x = 42
   let f x = x + x
 end
 
-let _ =
+let () =
   print_int M.x;
   let open M in
   print_int (f 42)
 
-let _ = print "\nInfix operators treated as sugar:\n"
+let () = print "\nInfix operators treated as sugar:\n"
 
 let succ n = n + 1
 let ignore_and_print_int () n = print_int n
-let _ = ignore_and_print_int () @@ succ @@ 1
-let _ = 2 |> succ |> ignore_and_print_int ()
+let () = ignore_and_print_int () @@ succ @@ 1
+let () = 2 |> succ |> ignore_and_print_int ()
 
-let _ = print "\n"
-let _ = caml_ml_flush stdout
+let () = print "\n"
+let () = caml_ml_flush stdout


### PR DESCRIPTION
This is another, slightly larger compile.scm feature: pattern in function arguments (and arguments of let-bound functions).

This raises the question of how exactly you want to define the boundary of miniml: is it "anything we care to implement", or where do we stop? (At which point do we start considering extending compile.scm to compile the ocaml-compiler fragment of OCaml?) Some thoughts:

- Adding more features to miniML is not so good as it introduces redundancies between the miniML implementation(s) and the compiler.
- I find it sensibly more time-consuming to hack on compile.scm than on the OCaml interpreter. Some of it is due to my lack of familiarity with Scheme, but I think it also comes in large part from the lack of static typing.

It would be interesting to compare the relative efficiency of ocamlc, ocamlopt, compile.scm, interp.byte and interp.opt on a miniML benchmark.

It is still fun to extend compile.scm, so maybe I will do more of that. What is the workflow you use to detect the features that are missing, and where they are used in the codebase? So far I just run compile.scm on interp.ml or eval.ml, but I only discover one missing feature at a time, and then I don't know where the other occurrences are in the codebase to understand how seriously we depend on the feature.