### PR TITLE
Pattern-matching compilation

### DIFF
--- a/miniml/compiler/compile.scm
+++ b/miniml/compiler/compile.scm
@@ -288,13 +288,9 @@
    (record_item_expr
     (longident_field EQ expr_no_semi) : (cons $1 $3))
 
-   (pattern_constr_args
-    (simple_pattern) : (cons $1 #nil)
-    (simple_pattern COMMA pattern_constr_args) : (cons $1 $3))
-
-   (comma_separated_list2_pattern_lident
-    (pattern_lident COMMA pattern_lident) : (cons $3 (cons $1 #nil))
-    (comma_separated_list2_pattern_lident COMMA pattern_lident) : (cons $3 $1))
+   (comma_separated_list2_pattern
+    (pattern COMMA pattern) : (cons $3 (cons $1 #nil))
+    (comma_separated_list2_pattern COMMA pattern) : (cons $3 $1))
 
    (comma_separated_list2_expr
     (expr_no_semi COMMA expr_no_semi) : (cons $3 (cons $1 #nil))
@@ -302,27 +298,18 @@
 
    (pattern
     (simple_pattern) : $1
-    (longident_constr pattern_lident) : (list 'PConstr $1 (cons $2 #nil))
-    (longident_constr LPAREN pattern_constr_args RPAREN) : (list 'PConstr $1 $3)
-    (comma_separated_list2_pattern_lident) :
-      ; For now we keep this production which is a bit out of touch with other constructs
-      ; that accept patterns rather than ident. A good plan would be to remove it entirely,
-      ; as it is a major source of conflicts, and just require that users
-      ; parenthesize their toplevel tuple patterns.
-      (lid->pconstr "" (reverse $1))
-    (simple_pattern COLONCOLON simple_pattern) : (lid->pconstr "::" (cons $1 (cons $3 #nil))))
+    (longident_constr simple_pattern) : (list 'PConstr $1 (cons $2 #nil))
+    (comma_separated_list2_pattern (prec: comma_prec)) : (lid->pconstr "" (reverse $1))
+    (pattern COLONCOLON pattern) : (lid->pconstr "::" (cons $1 (cons $3 #nil))))
 
    (simple_pattern
-    (pattern_lident) : $1
+    (lident_ext) : (if (equal? $1 "_") (list 'PWild) (list 'PVar $1))
     (longident_constr) : (list 'PConstr $1 #nil)
     (LBRACK RBRACK) : (lid->pconstr "[]" #nil)
     (LPAREN pattern COLON type_ignore RPAREN) : $2
     (LPAREN RPAREN) : (list 'PInt 0)
     (LPAREN pattern RPAREN) : $2
     (INT) : (list 'PInt $1))
-
-   (pattern_lident
-    (lident_ext) : (if (equal? $1 "_") (list 'PWild) (list 'PVar $1)))
 
    (simple_expr
     (longident_lident) : (list 'EVar $1)

--- a/miniml/compiler/compile.scm
+++ b/miniml/compiler/compile.scm
@@ -67,7 +67,7 @@
            MUTABLE OF OPEN REC SIG STRUCT TRY TYPE VAL WITH
            EOF STRING LIDENT UIDENT INT
            (right: MINUSGT)
-           (left: BAR)
+           (left: BAR AS)
            (nonassoc: annot_prec)
            (nonassoc: LET MATCH)
            (right: SEMICOLON)
@@ -300,7 +300,9 @@
     (simple_pattern) : $1
     (longident_constr simple_pattern) : (list 'PConstr $1 (cons $2 #nil))
     (comma_separated_list2_pattern (prec: comma_prec)) : (lid->pconstr "" (reverse $1))
-    (pattern COLONCOLON pattern) : (lid->pconstr "::" (cons $1 (cons $3 #nil))))
+    (pattern COLONCOLON pattern) : (lid->pconstr "::" (cons $1 (cons $3 #nil)))
+    (pattern AS LIDENT) : (list 'PAs $1 $3)
+   )
 
    (simple_pattern
     (lident_ext) : (if (equal? $1 "_") (list 'PWild) (list 'PVar $1))
@@ -430,6 +432,7 @@
 
 (define kw (list
     (cons "and" (cons 'AND #f))
+    (cons "as" (cons 'AS #f))
     (cons "asr" (cons 'INFIXOP4 "asr"))
     (cons "begin" (cons 'BEGIN #f))
     (cons "else" (cons 'ELSE #f))

--- a/miniml/compiler/compile.scm
+++ b/miniml/compiler/compile.scm
@@ -1746,7 +1746,7 @@
             (list
              'EMatch
              e
-             (list (cons p ('ELet #f bindings body))))))
+             (list (cons p (list 'ELet #f rest body))))))
       )))
   ))
 

--- a/miniml/compiler/test/exceptions.info.reference
+++ b/miniml/compiler/test/exceptions.info.reference
@@ -1,1 +1,1 @@
-Bytecode size:    6584 bytes
+Bytecode size:    6660 bytes

--- a/miniml/compiler/test/exits.info.reference
+++ b/miniml/compiler/test/exits.info.reference
@@ -1,1 +1,1 @@
-Bytecode size:    5704 bytes
+Bytecode size:    5748 bytes

--- a/miniml/compiler/test/external_exceptions.info.reference
+++ b/miniml/compiler/test/external_exceptions.info.reference
@@ -1,1 +1,1 @@
-Bytecode size:    7372 bytes
+Bytecode size:    7432 bytes

--- a/miniml/compiler/test/labels.info.reference
+++ b/miniml/compiler/test/labels.info.reference
@@ -1,1 +1,1 @@
-Bytecode size:    3982 bytes
+Bytecode size:    3998 bytes

--- a/miniml/compiler/test/let_open.info.reference
+++ b/miniml/compiler/test/let_open.info.reference
@@ -1,1 +1,1 @@
-Bytecode size:    3161 bytes
+Bytecode size:    3165 bytes

--- a/miniml/compiler/test/lists.info.reference
+++ b/miniml/compiler/test/lists.info.reference
@@ -1,1 +1,1 @@
-Bytecode size:    4118 bytes
+Bytecode size:    4142 bytes

--- a/miniml/compiler/test/patterns.info.reference
+++ b/miniml/compiler/test/patterns.info.reference
@@ -1,1 +1,1 @@
-Bytecode size:    6186 bytes
+Bytecode size:    6536 bytes

--- a/miniml/compiler/test/patterns.info.reference
+++ b/miniml/compiler/test/patterns.info.reference
@@ -1,1 +1,1 @@
-Bytecode size:    3259 bytes
+Bytecode size:    5004 bytes

--- a/miniml/compiler/test/patterns.info.reference
+++ b/miniml/compiler/test/patterns.info.reference
@@ -1,1 +1,1 @@
-Bytecode size:    8432 bytes
+Bytecode size:    5744 bytes

--- a/miniml/compiler/test/patterns.info.reference
+++ b/miniml/compiler/test/patterns.info.reference
@@ -1,1 +1,1 @@
-Bytecode size:    5744 bytes
+Bytecode size:    6186 bytes

--- a/miniml/compiler/test/patterns.info.reference
+++ b/miniml/compiler/test/patterns.info.reference
@@ -1,1 +1,1 @@
-Bytecode size:    6536 bytes
+Bytecode size:    8638 bytes

--- a/miniml/compiler/test/patterns.info.reference
+++ b/miniml/compiler/test/patterns.info.reference
@@ -1,1 +1,1 @@
-Bytecode size:    5004 bytes
+Bytecode size:    8432 bytes

--- a/miniml/compiler/test/patterns.ml
+++ b/miniml/compiler/test/patterns.ml
@@ -33,16 +33,16 @@ let test_nested_patterns =
   | Empty -> 0
   | Leaf _ -> 0
   | Node(_, Empty) -> 0
-  | Node(Empty, (Node _)) -> 1
-  | Node((Node _), (Node _)) -> 1
-  | Node((Leaf(0)), (Node (_, (Node (_, (Node _)))))) -> 2
-  | Node((Leaf(0)), (Node ((Leaf x), (Node ((Leaf y), Empty))))) -> x - y
-  | Node((Leaf(0)), (Node (_, Empty))) -> 4
+  | Node(Empty, Node _) -> 1
+  | Node(Node _, Node _) -> 1
+  | Node(Leaf 0, Node (_, Node (_, Node _))) -> 2
+  | Node(Leaf 0, Node (Leaf x, Node (Leaf y, Empty))) -> x - y
+  | Node(Leaf 0, Node (_, Empty)) -> 4
   | Node (a, b) ->
     (match Node (a, b) with
      | Node (Empty, _) -> 0
      | Node (_, Empty) -> 0
-     | Node ((Leaf _), (Leaf _)) -> 1
+     | Node (Leaf _, Leaf _) -> 1
      | _ -> 2)
 
 let () = print_int test_nested_patterns

--- a/miniml/compiler/test/patterns.ml
+++ b/miniml/compiler/test/patterns.ml
@@ -69,3 +69,37 @@ let () = print_int (match (2, 3) with
 )
 
 let () = print_newline ()
+let () = print "or-patterns: "
+
+(* toplevel ors, no parentheses *)
+let () = print_int (match 1 with
+  | 0 | 1 | 2 -> 1 (* no parentheses *)
+  | 3 | 4 -> 2
+  | 5 | _ -> 3
+)
+
+(* toplevel ors, with parentheses *)
+let () = print_int (match 3 with
+  | (0 | 1 | 2) -> 1
+  | (3 | 4) -> 2 (* parentheses *)
+  | 5 | _ -> 3
+)
+
+(* in-depth ors *)
+let () = print_int (match (2, 3) with
+  | ((0 | 1), _) -> 1
+  | (2, (0 | 1)) -> 2
+  | (2, (2 | 3)) -> 3
+  | ((3 | 4), _) -> 4
+  | _ -> 5
+)
+
+(* oring constant and non-constant patterns *)
+let () = print_int (match Node (Empty, Empty) with
+  | Empty | Leaf _ -> 0
+  | Node ((Empty | Leaf _), Node _) -> 1
+  | Node (_, (Empty | Leaf _)) -> 4
+  | Node (Node _, Node _) -> 12
+)
+
+let () = print_newline ()

--- a/miniml/compiler/test/patterns.ml
+++ b/miniml/compiler/test/patterns.ml
@@ -1,5 +1,7 @@
 let () = print_endline "Pattern-matching:"
 
+let () = print "simple: "
+
 let () =
   print_int (match [] with [] -> 2 | x :: l -> 3)
 
@@ -27,6 +29,16 @@ let () =
     | Leaf _ -> 4
     | Node _ -> 5 (* note: a single wildcard for several arguments *)
   )
+
+let () = print_newline ()
+let () = print "irrefutable patterns in let-bindings: "
+
+let () = print_int (
+  let (a, b) = (2, 3) in b - a
+)
+
+let () = print_newline ()
+let () = print "nested patterns: "
 
 let test_nested_patterns =
   match Node(Leaf 0, Node(Leaf 8, Node(Leaf 2, Empty))) with

--- a/miniml/compiler/test/patterns.ml
+++ b/miniml/compiler/test/patterns.ml
@@ -17,13 +17,29 @@ let () =
   print_int (test_function (3 :: []))
 
 type 'a tree =
+| Empty
 | Leaf of 'a
 | Node of 'a tree * 'a tree
 
 let () =
   print_int (match Node (Leaf 1, Leaf 2) with
+    | Empty -> 4
     | Leaf _ -> 4
     | Node _ -> 5 (* note: a single wildcard for several arguments *)
   )
+
+let test_nested_patterns =
+  match Node(Leaf 0, Node(Leaf 8, Node(Leaf 2, Empty))) with
+  | Empty -> 0
+  | Leaf _ -> 0
+  | Node(_, Empty) -> 0
+  | Node(Empty, (Node _)) -> 1
+  | Node((Node _), (Node _)) -> 1
+  | Node((Leaf(0)), (Node (_, (Node (_, (Node _)))))) -> 2
+  | Node((Leaf(0)), (Node ((Leaf x), (Node ((Leaf y), Empty))))) -> x - y
+  | Node((Leaf(0)), (Node (_, Empty))) -> 4
+  | Node (_, _) -> 5
+
+let () = print_int test_nested_patterns
 
 let () = print_newline ()

--- a/miniml/compiler/test/patterns.ml
+++ b/miniml/compiler/test/patterns.ml
@@ -60,3 +60,12 @@ let test_nested_patterns =
 let () = print_int test_nested_patterns
 
 let () = print_newline ()
+let () = print "as-patterns: "
+
+let () = print_int (match (2, 3) with
+  | (_ as a, _) as p ->
+    let (_, b) = p in
+    b - a
+)
+
+let () = print_newline ()

--- a/miniml/compiler/test/patterns.ml
+++ b/miniml/compiler/test/patterns.ml
@@ -38,7 +38,12 @@ let test_nested_patterns =
   | Node((Leaf(0)), (Node (_, (Node (_, (Node _)))))) -> 2
   | Node((Leaf(0)), (Node ((Leaf x), (Node ((Leaf y), Empty))))) -> x - y
   | Node((Leaf(0)), (Node (_, Empty))) -> 4
-  | Node (_, _) -> 5
+  | Node (a, b) ->
+    (match Node (a, b) with
+     | Node (Empty, _) -> 0
+     | Node (_, Empty) -> 0
+     | Node ((Leaf _), (Leaf _)) -> 1
+     | _ -> 2)
 
 let () = print_int test_nested_patterns
 

--- a/miniml/compiler/test/patterns.output.reference
+++ b/miniml/compiler/test/patterns.output.reference
@@ -2,3 +2,4 @@ Pattern-matching:
 simple:  2 3 4 5
 irrefutable patterns in let-bindings:  1
 nested patterns:  6
+as-patterns:  1

--- a/miniml/compiler/test/patterns.output.reference
+++ b/miniml/compiler/test/patterns.output.reference
@@ -3,3 +3,4 @@ simple:  2 3 4 5
 irrefutable patterns in let-bindings:  1
 nested patterns:  6
 as-patterns:  1
+or-patterns:  1 2 3 4

--- a/miniml/compiler/test/patterns.output.reference
+++ b/miniml/compiler/test/patterns.output.reference
@@ -1,2 +1,2 @@
 Pattern-matching:
- 2 3 4 5
+ 2 3 4 5 6

--- a/miniml/compiler/test/patterns.output.reference
+++ b/miniml/compiler/test/patterns.output.reference
@@ -1,2 +1,4 @@
 Pattern-matching:
- 2 3 4 5 6
+simple:  2 3 4 5
+irrefutable patterns in let-bindings:  1
+nested patterns:  6


### PR DESCRIPTION
This is a PR that implements compilation of nested patterns, by the usual technique of matrix decomposition.

(I thought of many ways to do it efficiently at the bytecode level, and I can tell you about the stack-layout scheme I devised, but in the end I decided to implement lowering precisely to do it at a more source-like level, for portability to a different backend for example.)

It appears that this conflict with changes done in trunk since my last pull, I will fix those this evening.

I have not implemented or-patterns yet, but they are not too hard to add on top of that, and used in my miniml. This is the next step.

The input grammar for pattern sorts of sucks (children have to be simple patterns so you have to write `Foo((Bar z),(Foobar x)))` instead of `Foo(Bar z, Foobar x)`). Generalizing it requires adding precedence levels to avoid conflicts, so some reengineering of the pattern grammar. I also plan to do this, but later.