### PR TITLE
Pattern cleanups

### DIFF
--- a/miniml/compiler/compile.scm
+++ b/miniml/compiler/compile.scm
@@ -246,8 +246,8 @@
     (longident_field EQ expr_no_semi) : (cons $1 $3))
 
    (pattern_constr_args
-    (lident_ext) : (cons $1 #nil)
-    (lident_ext COMMA pattern_constr_args) : (cons $1 $3))
+    (simple_pattern) : (cons $1 #nil)
+    (simple_pattern COMMA pattern_constr_args) : (cons $1 $3))
 
    (comma_separated_list2_lident
     (lident_ext COMMA lident_ext) : (cons $3 (cons $1 #nil))
@@ -259,10 +259,15 @@
 
    (pattern
     (simple_pattern) : $1
-    (longident_constr lident_ext) : (list 'PConstr $1 (cons $2 #nil))
+    (longident_constr lident_ext) : (list 'PConstr $1 (cons (lid->pvar $2) #nil))
     (longident_constr LPAREN pattern_constr_args RPAREN) : (list 'PConstr $1 $3)
-    (comma_separated_list2_lident) : (lid->pconstr "" (reverse $1))
-    (lident_ext COLONCOLON lident_ext) : (lid->pconstr "::" (cons $1 (cons $3 #nil))))
+    (comma_separated_list2_lident) :
+      ; For now we keep this production which is a bit out of touch with other constructs
+      ; that accept patterns rather than ident. A good plan would be to remove it entirely,
+      ; as it is a major source of conflicts, and just require that users
+      ; parenthesize their toplevel tuple patterns.
+      (lid->pconstr "" (map lid->pvar (reverse $1)))
+    (simple_pattern COLONCOLON simple_pattern) : (lid->pconstr "::" (cons $1 (cons $3 #nil))))
 
    (simple_pattern
     (lident_ext) : (list 'PVar $1)
@@ -1111,7 +1116,8 @@
                (tag (constr-get-tag cdef))
                (cnums (constr-get-numconstrs cdef))
                (const (mkswitch-const tag e))
-               (block (mkswitch-block tag arity l e))
+               (vars (map (match-lambda (('PVar v) v)) l))
+               (block (mkswitch-block tag arity vars e))
                (sw (switch-merge-nums sw-rest cnums)))
           (match l
             (#nil
@@ -1560,7 +1566,7 @@
    (('PInt _)
     env)
    (('PConstr c l)
-    (fold fv-env-var env l))))
+    (fold fv-env-pat env l))))
 
 
 (define (range a b) (if (>= a b) #nil (cons a (range (+ a 1) b))))
@@ -1672,7 +1678,7 @@
 
 (define (compile-arg-default name default body)
   (let* ((noneline (cons (lid->pconstr "None" #nil) default))
-         (someline (cons (lid->pconstr "Some" (list name))
+         (someline (cons (lid->pconstr "Some" (list (lid->pvar name)))
                          (lid->evar name)))
          (default-expr (list 'EMatch (lid->evar name) (list noneline someline))))
     (list 'ELet #f (list (cons (lid->pvar name) default-expr)) body)))

--- a/miniml/compiler/compile.scm
+++ b/miniml/compiler/compile.scm
@@ -249,9 +249,9 @@
     (simple_pattern) : (cons $1 #nil)
     (simple_pattern COMMA pattern_constr_args) : (cons $1 $3))
 
-   (comma_separated_list2_lident
-    (lident_ext COMMA lident_ext) : (cons $3 (cons $1 #nil))
-    (comma_separated_list2_lident COMMA lident_ext) : (cons $3 $1))
+   (comma_separated_list2_pattern_lident
+    (pattern_lident COMMA pattern_lident) : (cons $3 (cons $1 #nil))
+    (comma_separated_list2_pattern_lident COMMA pattern_lident) : (cons $3 $1))
 
    (comma_separated_list2_expr
     (expr_no_semi COMMA expr_no_semi) : (cons $3 (cons $1 #nil))
@@ -259,24 +259,27 @@
 
    (pattern
     (simple_pattern) : $1
-    (longident_constr lident_ext) : (list 'PConstr $1 (cons (lid->pvar $2) #nil))
+    (longident_constr pattern_lident) : (list 'PConstr $1 (cons $2 #nil))
     (longident_constr LPAREN pattern_constr_args RPAREN) : (list 'PConstr $1 $3)
-    (comma_separated_list2_lident) :
+    (comma_separated_list2_pattern_lident) :
       ; For now we keep this production which is a bit out of touch with other constructs
       ; that accept patterns rather than ident. A good plan would be to remove it entirely,
       ; as it is a major source of conflicts, and just require that users
       ; parenthesize their toplevel tuple patterns.
-      (lid->pconstr "" (map lid->pvar (reverse $1)))
+      (lid->pconstr "" (reverse $1))
     (simple_pattern COLONCOLON simple_pattern) : (lid->pconstr "::" (cons $1 (cons $3 #nil))))
 
    (simple_pattern
-    (lident_ext) : (list 'PVar $1)
+    (pattern_lident) : $1
     (longident_constr) : (list 'PConstr $1 #nil)
     (LBRACK RBRACK) : (lid->pconstr "[]" #nil)
     (LPAREN pattern COLON type_ignore RPAREN) : $2
     (LPAREN RPAREN) : (list 'PInt 0)
     (LPAREN pattern RPAREN) : $2
     (INT) : (list 'PInt $1))
+
+   (pattern_lident
+    (lident_ext) : (if (equal? $1 "_") (list 'PWild) (list 'PVar $1)))
 
    (simple_expr
     (longident_lident) : (list 'EVar $1)
@@ -1103,6 +1106,8 @@
     (#nil empty-switch)
     (((p . e) . rest)
      (match p
+       (('PWild)
+        (switch-with-default empty-switch (cons #nil e)))
        (('PVar v)
         (switch-with-default empty-switch (cons v e)))
        (('PInt n)
@@ -1116,14 +1121,16 @@
                (tag (constr-get-tag cdef))
                (cnums (constr-get-numconstrs cdef))
                (const (mkswitch-const tag e))
-               (vars (map (match-lambda (('PVar v) v)) l))
+               (vars (map (match-lambda
+                           (('PVar v) v)
+                           (('PWild) #nil)) l))
                (block (mkswitch-block tag arity vars e))
                (sw (switch-merge-nums sw-rest cnums)))
           (match l
             (#nil
              (assert (or (= arity 0) (= arity -1)))
              (switch-cons-const sw const))
-            (("_")
+            (('PWild)
               (switch-cons-block sw block))
             (_
              (assert (or (= arity -1) (= arity (length l))))
@@ -1137,7 +1144,7 @@
 (define (compile-bind-fields env stacksize istail vars e)
   (match-let (((i j env) (fold
              (match-lambda* ((var (i j env))
-               (if (equal? var "_")
+               (if (null? var)
                    (list (+ i 1) j env)
                    (let* ((nenv (localvar env var (+ stacksize j))))
                      (bytecode-put-u32-le ACC)
@@ -1153,7 +1160,7 @@
   ))
 
 (define (compile-bind-var env stacksize istail var e)
-  (if (equal? var "_")
+  (if (null? var)
       (compile-expr env stacksize istail e)
       (begin
         (bytecode-put-u32-le PUSH)
@@ -1162,14 +1169,16 @@
         (bytecode-put-u32-le 1))))
 
 (define (compile-bind-var-with-shape env stacksize istail var e shape)
-  (bytecode-put-u32-le PUSH)
-  (compile-expr (localvar-with-shape env var stacksize shape) (+ stacksize 1) istail e)
-  (bytecode-put-u32-le POP)
-  (bytecode-put-u32-le 1))
-
+  (if (null? var)
+      (compile-expr env stacksize istail e)
+      (begin
+        (bytecode-put-u32-le PUSH)
+        (compile-expr (localvar-with-shape env var stacksize shape) (+ stacksize 1) istail e)
+        (bytecode-put-u32-le POP)
+        (bytecode-put-u32-le 1))))
 
 (define (compile-bind-var-pushed env stacksize istail var e)
-  (if (equal? var "_")
+  (if (null? var)
       (begin
         (bytecode-put-u32-le POP)
         (bytecode-put-u32-le 1)
@@ -1225,11 +1234,12 @@
                     (bytecode-put-u32-le C_CALL1)
                     (bytecode-put-u32-le obj_tag)))
               (for-each (match-lambda (($ <switch-block> i _ l e)
-                          (let* ((lab (newlabel)))
+                          (let* ((lab (newlabel))
+                                 (l (if exntype (cons #nil l) l)))
                             (bytecode-put-u32-le BNEQ)
                             (bytecode-put-u32-le i)
                             (bytecode-emit-labref lab)
-                            (compile-bind-fields env (+ stacksize 1) istail (if exntype (cons "_" l) l) e)
+                            (compile-bind-fields env (+ stacksize 1) istail l e)
                             (bytecode-put-u32-le BRANCH)
                             (bytecode-emit-labref endlab)
                             (bytecode-emit-label lab)
@@ -1345,7 +1355,7 @@
      (let* ((var "try#exn"))
        (list 'LCatch e var (list 'EMatch (lid->evar var)
          (append m (list
-           (cons (list 'PVar "_") (list 'LReraise (lid->evar var)))))))))
+           (cons (list 'PWild) (list 'LReraise (lid->evar var)))))))))
     (('ELet rec-flag bindings body)
        (if rec-flag
          (list 'LLetrecfun bindings body)
@@ -1355,6 +1365,8 @@
             (list 'LLetfun v args fun body))
            ((('PVar v) . e)
             (list 'LLet v e body))
+           ((('PWild) . e)
+            (list 'EChain e body))
            ((p . e)
             (list 'EMatch e (list (cons p body)))))
         ) body bindings)))
@@ -1561,6 +1573,8 @@
 
 (define (fv-env-pat p env)
   (match p
+   (('PWild)
+    env)
    (('PVar v)
     (fv-env-var v env))
    (('PInt _)
@@ -1684,9 +1698,11 @@
     (list 'ELet #f (list (cons (lid->pvar name) default-expr)) body)))
 
 (define (compile-arg-pat pat name body)
-  (if (equal? (car pat) 'PVar)
-      body
-      (list 'EMatch (lid->evar name) (list (cons pat body)))))
+  (match pat
+   (('PVar _)
+    body)
+   (_
+    (list 'EMatch (lid->evar name) (list (cons pat body))))))
 
 (define empty-numtags (cons 0 0))
 (define (numtags-next arity numtags)

--- a/miniml/compiler/hello.ml
+++ b/miniml/compiler/hello.ml
@@ -99,7 +99,7 @@ let () =
 
 let test_function = function
   | [] -> 2
-  | x :: l -> x + 1
+  | x :: _ -> x + 1 (* note: one of the pattern arguments is a wildcard *)
 
 let () =
   print_int (test_function (3 :: []))

--- a/miniml/compiler/hello.ml
+++ b/miniml/compiler/hello.ml
@@ -95,7 +95,7 @@ let () =
 let () =
   print_int (match 1 :: [] with
     | [] -> 2 (* note: leading bar *)
-    | x :: l -> 3)
+    | _ :: _ -> 3)
 
 let test_function = function
   | [] -> 2
@@ -103,6 +103,15 @@ let test_function = function
 
 let () =
   print_int (test_function (3 :: []))
+
+type 'a tree =
+| Leaf of 'a
+| Node of 'a tree * 'a tree
+
+let () = print_int (match Node (Leaf 1, Leaf 2) with
+  | Leaf _ -> 4
+  | Node _ -> 5 (* note: a single wildcard for several arguments *)
+)
 
 let () = print "\nLists:\n"
 


### PR DESCRIPTION
This is the innocuous part of the pattern-matching compilation PR #13 that makes the AST of patterns more regular and introduces a proper `'PWildcard` instead of hard-coded `"_"`, but does not introduce changes to the compilation strategy. (In particular there is no code duplication of pattern right-hand-sides, ever.)

I would be in favor of merging this to master quickly, even if we delay #13, to be used as a starting point for further refactorings.