### PR TITLE
Compiler testsuite: track the size of bytecode executables

### DIFF
--- a/miniml/compiler/test/.gitignore
+++ b/miniml/compiler/test/.gitignore
@@ -1,2 +1,3 @@
 *.byte
 *.output
+*.info

--- a/miniml/compiler/test/Makefile
+++ b/miniml/compiler/test/Makefile
@@ -44,11 +44,13 @@ promote: $(addprefix promote-,$(TESTS))
 clean:
 	rm -f *.byte *.output *.info
 
-test-%: %.byte %.output
+test-%: %.byte %.output %.info
 	diff -u --report-identical-files $*.output.reference $*.output
+	diff -u --report-identical-files $*.info.reference $*.info
 
-promote-%: %.byte %.output
+promote-%: %.byte %.output %.info
 	cp $*.output $*.output.reference
+	cp $*.info $*.info.reference
 
 .PHONY: always-rerun
 always-rerun:
@@ -58,3 +60,7 @@ always-rerun:
 
 %.output: always-rerun %.byte
 	$(OCAMLRUN) $*.byte > $*.output
+
+%.info: always-rerun %.byte
+	rm -f $*.info
+	stat --printf="Bytecode size: %7s bytes\n" $*.byte >> $*.info

--- a/miniml/compiler/test/arith.info.reference
+++ b/miniml/compiler/test/arith.info.reference
@@ -1,0 +1,1 @@
+Bytecode size:    4056 bytes

--- a/miniml/compiler/test/empty.info.reference
+++ b/miniml/compiler/test/empty.info.reference
@@ -1,0 +1,1 @@
+Bytecode size:    2756 bytes

--- a/miniml/compiler/test/exceptions.info.reference
+++ b/miniml/compiler/test/exceptions.info.reference
@@ -1,0 +1,1 @@
+Bytecode size:    7016 bytes

--- a/miniml/compiler/test/external_exceptions.info.reference
+++ b/miniml/compiler/test/external_exceptions.info.reference
@@ -1,0 +1,1 @@
+Bytecode size:    7844 bytes

--- a/miniml/compiler/test/functions.info.reference
+++ b/miniml/compiler/test/functions.info.reference
@@ -1,0 +1,1 @@
+Bytecode size:    5911 bytes

--- a/miniml/compiler/test/functors.info.reference
+++ b/miniml/compiler/test/functors.info.reference
@@ -1,0 +1,1 @@
+Bytecode size:    3468 bytes

--- a/miniml/compiler/test/infix_sugar.info.reference
+++ b/miniml/compiler/test/infix_sugar.info.reference
@@ -1,0 +1,1 @@
+Bytecode size:    3300 bytes

--- a/miniml/compiler/test/labels.info.reference
+++ b/miniml/compiler/test/labels.info.reference
@@ -1,0 +1,1 @@
+Bytecode size:    4374 bytes

--- a/miniml/compiler/test/let_open.info.reference
+++ b/miniml/compiler/test/let_open.info.reference
@@ -1,0 +1,1 @@
+Bytecode size:    3108 bytes

--- a/miniml/compiler/test/lists.info.reference
+++ b/miniml/compiler/test/lists.info.reference
@@ -1,0 +1,1 @@
+Bytecode size:    4578 bytes

--- a/miniml/compiler/test/patterns.info.reference
+++ b/miniml/compiler/test/patterns.info.reference
@@ -1,0 +1,1 @@
+Bytecode size:    3551 bytes

--- a/miniml/compiler/test/records.info.reference
+++ b/miniml/compiler/test/records.info.reference
@@ -1,0 +1,1 @@
+Bytecode size:    3561 bytes


### PR DESCRIPTION
This PR, on top of #27, tracks the size of each bytecode executable. For each test `foo`, a file `foo.info` is produced by running the test, and a file `foo.info.reference` is stored in version control.

The goal is to see, when we change the compiler, if we got an improvement or a regression in code size. (This was not possible without splitting the test, as any addition to `hello.ml` would make the numbers meaningless.)

It would be useful to also keep track of the instruction count of each testfile, but the OCaml bytecode interpreter does not compute or provide this information.