### PR TITLE
substitution-on-the-fly as a generalization of the (let x = y in ...) optimization

### DIFF
--- a/miniml/compiler/test/exits.info.reference
+++ b/miniml/compiler/test/exits.info.reference
@@ -1,1 +1,1 @@
-Bytecode size:    5668 bytes
+Bytecode size:    5704 bytes

--- a/miniml/compiler/test/exits.ml
+++ b/miniml/compiler/test/exits.ml
@@ -87,7 +87,7 @@ let () =
   try
     let%exit ex n = raise (Foo (n + 2)) in
     try
-      let v = 1 in
+      let v = 1+0 in
       [%exit] ex v
     with Foo n -> print_int (2 * n)
   with Foo n -> print_int n

--- a/miniml/compiler/test/functions.info.reference
+++ b/miniml/compiler/test/functions.info.reference
@@ -1,1 +1,1 @@
-Bytecode size:    6010 bytes
+Bytecode size:    6404 bytes

--- a/miniml/compiler/test/functions.ml
+++ b/miniml/compiler/test/functions.ml
@@ -54,10 +54,17 @@ let () =
   print_int (sum1 0); print_int (sum2 0)
 
 let () = print_newline ()
-let () = print "stack tests: "
+let () = print "let-binding tests: "
 
 let () = print_int (let a = 17 in let b = 42 in if (let x = 2 in true) then a else b)
 let () = print_int (let a = 17 in let b = 42 in if (let x = 2 in false) then a else b)
+
+(* this ensures that the 'let' are not substituted away... as long as we don't support constant-folding *)
+let () = print_int (let a = 16+1 in let b = 41+1 in if (let x = 1+1 in true) then a else b)
+let () = print_int (let a = 16+1 in let b = 41+1 in if (let x = 1+1 in false) then a else b)
+
+(* regression test for an infinite loop in 'Subst unfolding *)
+let () = print_int (let x = 21 in let y = x in let x = y in x + y)
 
 let () = print_newline ()
 let () = print "more recursion: "

--- a/miniml/compiler/test/functions.output.reference
+++ b/miniml/compiler/test/functions.output.reference
@@ -4,5 +4,5 @@ currified:  42
 higher-order:  42 65536 42 17 42
 local:  42
 recursive:  45 20 25
-stack tests:  17 42
+let-binding tests:  17 42 17 42 42
 more recursion:  10 9 8 7 6 5 4 3 2 1

--- a/miniml/compiler/test/records.info.reference
+++ b/miniml/compiler/test/records.info.reference
@@ -1,1 +1,1 @@
-Bytecode size:    3237 bytes
+Bytecode size:    3205 bytes


### PR DESCRIPTION
I was starting to rebase the pattern-matching work on top of the current `master`, but I realize that the variable-rebinding optimization could (and should) be generalized.

For the "should" part: after replaying the variable-rebinding optimization on the current master, I observe smaller bytecode-size savings on the testsuite (which does not yet use the new pattern-matching compilation strategy). I believe that the reason is that some of the `EVar` are lowered into `LGlob`, which is not covered by just optimizing the `LLet x (LVar y) e` case.

Note that in some rare cases this could be a pessimization, if a value is rebound locally and then used many times, it may be able to use one of the short specialized `ACCn` opcode.

Once the `local-exits` branch is merged I should also be able to implement the symmetric optimization for exits whose right-hand-side is substituable.