### PR TITLE
pattern-matching: do not generate a default case when groups are complete

### DIFF
--- a/miniml/compiler/test/exceptions.info.reference
+++ b/miniml/compiler/test/exceptions.info.reference
@@ -1,1 +1,1 @@
-Bytecode size:    7052 bytes
+Bytecode size:    6988 bytes

--- a/miniml/compiler/test/lists.info.reference
+++ b/miniml/compiler/test/lists.info.reference
@@ -1,1 +1,1 @@
-Bytecode size:    5374 bytes
+Bytecode size:    5266 bytes

--- a/miniml/compiler/test/patterns.info.reference
+++ b/miniml/compiler/test/patterns.info.reference
@@ -1,1 +1,1 @@
-Bytecode size:    9498 bytes
+Bytecode size:    9234 bytes


### PR DESCRIPTION
This is a small optimization of pattern-matching that I wrote because I hoped it would reduce code size (while being simple to implement). It does reduce code size, but less than I had hoped.