### PR TITLE
fix the (apparently generated?) .mli files in interpreter/

### DIFF
--- a/interpreter/Makefile
+++ b/interpreter/Makefile
@@ -27,6 +27,9 @@ format:
 .ml.cmo:
 	$(OCAML) $(FLAGS) -c $<
 
+.mli.cmi:
+	$(OCAML) $(FLAGS) -c $<
+
 .depend: $(SRCS)
 	ocamldep $(SRCS) > .depend
 

--- a/interpreter/data.mli
+++ b/interpreter/data.mli
@@ -101,7 +101,7 @@ exception InternalException of value
 val unit : value_ Ptr.t
 val is_true : value_ Ptr.t -> bool
 val pp_print_value : Format.formatter -> value_ Ptr.t -> unit
-val pp_print_unit_id : Format.formatter -> module_unit_id -> 'a
+val pp_print_unit_id : Format.formatter -> module_unit_id -> unit
 val read_caml_int : string -> int64
 val value_of_constant : Parsetree.constant -> value_ Ptr.t
 val value_compare : value_ Ptr.t -> value_ Ptr.t -> int
@@ -112,5 +112,5 @@ val value_gt : value_ Ptr.t -> value_ Ptr.t -> bool
 val value_ge : value_ Ptr.t -> value_ Ptr.t -> bool
 val next_exn_id : unit -> int
 exception No_module_data
-val get_module_data : 'a -> mdl -> mdl_val
+val get_module_data : Location.t -> mdl -> mdl_val
 val module_name_of_unit_path : string -> string

--- a/interpreter/envir.mli
+++ b/interpreter/envir.mli
@@ -19,7 +19,7 @@ val decompose :
   env -> Longident.t Asttypes.loc -> string * env * string
 val lookup :
   string ->
-  env_name:'a -> ('b * 'c) SMap.t -> SMap.key Asttypes.loc -> 'c
+  env_name:string -> ('a * 'b) SMap.t -> SMap.key Asttypes.loc -> 'b
 val env_get_module : env -> Longident.t Asttypes.loc -> mdl
 val env_get_value_or_lvar :
   env -> Longident.t Asttypes.loc -> value_or_lvar

--- a/interpreter/eval.mli
+++ b/interpreter/eval.mli
@@ -8,8 +8,8 @@ val expr_label_shape :
 val fun_label_shape :
   value_ ->
   (Asttypes.arg_label * Parsetree.expression option) list
-val mismatch : 'a -> 'b
-val unsupported : 'a -> 'b
+val mismatch : Location.t -> unit
+val unsupported : Location.t -> unit
 val take : int -> 'a list -> 'a list
 val apply :
   value SMap.t ->

--- a/interpreter/runtime_base.mli
+++ b/interpreter/runtime_base.mli
@@ -1,6 +1,6 @@
 open Data
 
-val type_error : 'a -> 'b -> 'c
+val type_error : string -> Data.value_ -> 'a
 val wrap_int : int -> value
 val unwrap_int : value -> int
 val wrap_int32 : int32 -> value


### PR DESCRIPTION
I tried to compile the interpreter codebase using OCaml (not miniml), and currently this appears to fail. I don't know when the issue started, and why we have auto-generated `.mli` files in there. (In general I would rather optimize for maintainability, so either no `.mli` files or human-written ones. I don't mind writing `.mli` files myself if we decide to go that way.)