### PR TITLE
Makefile: build for any architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ configure-ocaml:
 	$(MAKE) -C $(OCAMLSRC) ocamlyacc && cp $(OCAMLSRC)/yacc/ocamlyacc $(OCAMLSRC)/boot
 	$(MAKE) -C $(OCAMLSRC)/lex parser.ml
 
+# Here, including $(CONFIG) would provide $(ARCH), but it leads to a recursive
+# dependency because its rule has a dependency that reloads this Makefile.
 .PHONY: ocaml-generated-files
 ocaml-generated-files: $(OCAMLRUN) lex make_opcodes cvt_emit
 	$(MAKE) -C $(OCAMLSRC)/stdlib sys.ml
@@ -28,7 +30,7 @@ ocaml-generated-files: $(OCAMLRUN) lex make_opcodes cvt_emit
 	$(MAKE) -C $(OCAMLSRC) bytecomp/runtimedef.ml
 	miniml/interp/make_opcodes.sh -opcodes < $(OCAMLSRC)/byterun/caml/instruct.h > $(OCAMLSRC)/bytecomp/opcodes.ml
 	$(MAKE) -C $(OCAMLSRC) asmcomp/arch.ml asmcomp/proc.ml asmcomp/selection.ml asmcomp/CSE.ml asmcomp/reload.ml asmcomp/scheduling.ml
-	miniml/interp/cvt_emit.sh < $(OCAMLSRC)/asmcomp/amd64/emit.mlp > $(OCAMLSRC)/asmcomp/emit.ml
+	miniml/interp/cvt_emit.sh < $(OCAMLSRC)/asmcomp/$(shell cat $(CONFIG) | grep '^ARCH=' | cut -f2 -d=)/emit.mlp > $(OCAMLSRC)/asmcomp/emit.ml
 
 .PHONY: lex
 lex: $(OCAMLRUN)


### PR DESCRIPTION
Hi!

This small change should allow to build for other architectures. Right now, amd64 is hard-coded in the Makefile, which leads to assembly errors such as `/tmp/guix-build-camlboot-0.0.0-0.506280c.drv-0/camlasm6cb05b.s:31: Error: unknown mnemonic 'subq' -- 'subq $8,%rsp'`. Indeed, `subq`, `%rsp`, etc are specific to amd64.

I replaced the hard-coded `amd64` with `$(ARCH)`, which is generated by OCaml's configure script. I initially tried to `include $(CONFIG)`, but that leads to a recursive loading of the Makefile. Instead, I replaced the hard-coded `amd64` with some shell code that should load the arch set in `$(CONFIG)`.

Without the changes from #3 this does not work yet for i686, but it should work for any other 64-bits architectures, such as `aarch64`. I don't have a system to test that hypothesis though. I was able to build on x86_64 with this patch, so there shouldn't be regressions (well, that was very unlikely given that for this architecture, the Makefile ends doing the exact same thing).

I have a separate branch where I pushed this patch on top of @gasche changes, and I was able to build for i686-linux with both our changes.