### PR TITLE
Don't import "map" twice in compile.scm

### DIFF
--- a/miniml/compiler/compile.scm
+++ b/miniml/compiler/compile.scm
@@ -1,6 +1,6 @@
 (use-modules (system base lalr)
              (srfi srfi-1) (srfi srfi-9 gnu)
-             (rnrs base)
+             ((rnrs base) #:select (assert))
              (ice-9 q)
              (ice-9 binary-ports) (ice-9 vlist) (ice-9 match))
 


### PR DESCRIPTION
Fixes this Guile warning when running `guile compile.scm`:

> WARNING: (guile-user): `map' imported from both (srfi srfi-1) and
> (rnrs base)

Tested with Guile 2.2.7 and 3.0.8.

(This is an extremely cool project, kudos!)